### PR TITLE
Fixed typo on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ This github action scans a repository usuing Yelp's [Detect Secrets](https://git
 
 ```
 - name: Detect Secrets
-  uses: evanextreme/detect-secrets@1.0.0
+  uses: evanextreme/detect-secrets-action@1.0.0
 ```


### PR DESCRIPTION
Repo name was spelled wrong. Therefore GitHub Action was not able to check out the repository.